### PR TITLE
Optimize Event Count Handling in Metrics Buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dark-mechanicum/aws-cloudwatch-metrics-http-gateway",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dark-mechanicum/aws-cloudwatch-metrics-http-gateway",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.635.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dark-mechanicum/aws-cloudwatch-metrics-http-gateway",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "HTTP Gateway to Receive and Process AWS Cloudwatch Metrics",
   "main": "index.js",
   "scripts": {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -76,9 +76,9 @@ class MetricsBuffer {
 
     for (const [namespace, metrics] of this.buffer) {
       const metricArray: MetricDatum[] = Array.from(metrics.values());
+      eventsUploaded += metricArray.length;
 
       for (let i = 0; i < metricArray.length; i += 1000) {
-        eventsUploaded += metricArray.length;
 
         const chunk: MetricDatum[] = metricArray.slice(i, i + 1000);
 


### PR DESCRIPTION
This pull request introduces an optimization to the handling of event counts within the `MetricsBuffer` class of the AWS Cloudwatch Metrics HTTP Gateway. The changes are aimed at improving the accuracy and efficiency of metrics processing. Key updates include:

- **Event Count Adjustment**: Adjusted the point where `eventsUploaded` is incremented to outside the inner loop. This modification ensures that the count of uploaded events is accurately maintained across multiple iterations, avoiding redundant additions that previously occurred within the loop.
- **Code Optimization**: Moved the update of `eventsUploaded` before the loop that processes metric chunks, which clarifies the flow of data and reduces the complexity within the loop, potentially improving the execution performance when processing large sets of metrics data.